### PR TITLE
Persist parsed and unstructured CV

### DIFF
--- a/src/app/api/cv/route.ts
+++ b/src/app/api/cv/route.ts
@@ -83,7 +83,6 @@ export async function POST(req: NextRequest, res: NextResponse) {
     }
     
     console.log('Parsed the CV, structuring it...');
-
     const chatResp = openAI.chat.completions.create({
       model: 'gpt-3.5-turbo',
       messages: [


### PR DESCRIPTION
## What

Persist the parsed text from the CV to database.

## Why

This is helpful when we want to debug if the resume parsing has not been working correctly. For example, if the reading from a docx or pdf has not been working well or the chat-gpt restructuring hasn't worked well. This also provides us extra data if we ever want to train our own (language) model to do the structuring of the CV so we can use it as training data.