### PR TITLE
Add unity IDs to work experience entries

### DIFF
--- a/src/app/api/cv/route.ts
+++ b/src/app/api/cv/route.ts
@@ -20,6 +20,38 @@ interface TextContextItem {
   str: string;
 }
 
+interface StructuredCV {
+  name: string;
+  personal_information: {
+    email: string;
+    phone_number: string;
+    about_me: string;
+  };
+  work_experience: {
+    company_name: string;
+    position: string;
+    location: string;
+    start_date: string;
+    end_date: string;
+    responsibilities: string[];
+  }[];
+  personal_projects: {
+    name: string;
+    start_date: string;
+    end_date: string;
+  }[];
+  education: {
+    degree: string;
+    location: string;
+    start_date: string;
+    end_date: string;
+    grade: string;
+  }[];
+  technical_skills: string[];
+  languages: string[];
+  interests: string[];
+}
+
 enum FileType {
   PDF = 'application/pdf',
   DOCX = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
@@ -207,7 +239,7 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  let structuredCVContent;
+  let structuredCVContent: StructuredCV;
   try {
     structuredCVContent = JSON.parse(chatResp?.choices[0]?.message?.content!);
     if (!structuredCVContent) {

--- a/src/app/api/cv/route.ts
+++ b/src/app/api/cv/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt'
 import mammoth from 'mammoth';
+import { v4 as uuidv4 } from 'uuid';
 import OpenAI from 'openai';
 import prisma from '../../../lib/prisma';
 
@@ -28,6 +29,7 @@ interface StructuredCV {
     about_me: string;
   };
   work_experience: {
+    id: string;
     company_name: string;
     position: string;
     location: string;
@@ -265,13 +267,18 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  structuredCVContent.work_experience.map((exp) => {
+    exp.id = uuidv4();
+    return exp;
+  });
+
   console.log('Stuctured the CV, persisting it...');
   try {
     await prisma.structuredCVs.create({
       data: {
         ownerId: user.id,
         parsedCVId: parsedCV.id,
-        content: structuredCVContent,
+        content: structuredCVContent as any,
       }
     });
   } catch (err) {


### PR DESCRIPTION
## What

Add unique IDs (UUID) to work experience entries when persisting to DB.

## Why

To specify operation to specific entries in the candidates work experience, like rewriting the responsibilities. When we have unique IDs, we can design our APIs to operate to specific jobs.