### PR TITLE
Coverletter endpoints and some related changes to the front-end

### DIFF
--- a/src/app/api/coverletter/[id]/route.ts
+++ b/src/app/api/coverletter/[id]/route.ts
@@ -1,0 +1,152 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+import prisma from '../../../../lib/prisma';
+
+export async function GET(req: NextRequest) {
+  console.log('Getting stored coverletter...');
+
+  const token = await getToken({ req });
+  if (!token && token != null) {
+    console.log('invalid token');
+    return NextResponse.json(
+      {
+        body: {
+          message: 'invalid token',
+        },
+      },
+      { status: 401 },
+    );
+  }
+
+  if (!token?.sub) {
+    console.log('No user ID provided');
+    return NextResponse.json(
+      {
+        body: {
+          message: 'no user ID provided',
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const coverletterId = req.nextUrl.pathname.split('/').pop();
+  if (!coverletterId) {
+    console.log('No coverletter ID provided');
+    return NextResponse.json(
+      {
+        body: {
+          message: 'no coverletter ID provided',
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  console.log(`Fetching coverletter id: ${coverletterId}`);
+
+  let coverletter;
+  try {
+    coverletter = await prisma.coverLetters.findUnique({
+      where: {
+        ownerId: token?.sub,
+        id: coverletterId,
+      },
+      select: {
+        id: true,
+        content: true,
+      },
+    });
+  } catch (err) {
+    console.log(`Fetching coverletter: ${err}`);
+    return NextResponse.json(
+      {
+        body: {
+          message: 'internal server error',
+        },
+      },
+      { status: 500 },
+    );
+  }
+
+  if (!coverletter || !coverletter.content) {
+    console.log('No coverletter found');
+    return NextResponse.json(
+      {
+        body: {
+          message: 'no coverletter found',
+        },
+      },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      body: {
+        id: coverletter?.id,
+        profile: coverletter?.content,
+      },
+    },
+    { status: 200 },
+  );
+}
+
+export async function DELETE(req: NextRequest) {
+  const token = await getToken({ req });
+  if (!token) {
+    console.log('invalid token');
+    return NextResponse.json(
+      {
+        body: {
+          message: 'invalid token',
+        },
+      },
+      { status: 401 },
+    );
+  }
+
+  const coverletterId = req.nextUrl.pathname.split('/').pop();
+  if (!coverletterId) {
+    console.log('No coverletter ID provided');
+    return NextResponse.json(
+      {
+        body: {
+          message: 'no CV ID provided',
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  console.log(`Deleting coverletter id: ${coverletterId}`);
+
+  try {
+    await prisma.coverLetters.delete({
+      where: {
+        id: coverletterId,
+      },
+    });
+  } catch (err) {
+    console.log(`Error deleting CV: ${err}`);
+    return NextResponse.json(
+      {
+        body: {
+          message: 'internal server error',
+        },
+      },
+      { status: 500 },
+    );
+  }
+
+  console.log('Successfully deleted the coverletter');
+
+  return NextResponse.json(
+    {
+      body: {
+        message: 'coverletter deleted successfully',
+      },
+    },
+    { status: 200 },
+  );
+}

--- a/src/app/api/coverletterChanges/route.ts
+++ b/src/app/api/coverletterChanges/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt'
+import { Coverletter, CoverletterSchema } from '@/types/profile';
+import prisma from '../../../lib/prisma';
+
+export async function POST(req: NextRequest) {
+  const token = await getToken({ req });
+  if (!token || !token.sub) {
+    console.log('invalid token');
+    return NextResponse.json(
+      {
+        body: {
+          message: 'invalid token',
+        }
+      },
+      { status: 401 }
+    );
+  }
+
+  let { id, coverletter: coverletter } = (await req.json()) as { id: string, coverletter: Coverletter };
+  if (!coverletter || !id) {
+    return NextResponse.json(
+      {
+        body: {
+          message: 'Resume or id not provided',
+        }
+      },
+      { status: 400 }
+    );
+  }
+
+  const isValid = CoverletterSchema.safeParse(coverletter);
+  if (!isValid.success) {
+    console.log(`Invalid coverletter: ${isValid.error}`);
+    return NextResponse.json(
+      {
+        body: {
+          message: 'invalid coverletter',
+        }
+      },
+      { status: 400 }
+    );
+  }
+
+  console.log('Updating the coverletter...');
+  try {
+    await prisma.coverLetters.update({
+      where: {
+        id: id,
+        ownerId: token.sub,
+      },
+      data: {
+        content: coverletter as any,
+      }
+    });
+  } catch (err) {
+    console.log(`Update coverLetters: ${err}`);
+    return NextResponse.json(
+      {
+        body: {
+          message: 'internal server error',
+        }
+      },
+      { status: 500 }
+    );
+  }
+
+  console.log('Successfully updated the coverletter');
+
+  return NextResponse.json(
+    {
+      body: {
+        message: 'success',
+      }
+    },
+    { status: 200 }
+  );
+}

--- a/src/app/api/resume/upload/route.ts
+++ b/src/app/api/resume/upload/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt'
+import { Coverletter, CoverletterSchema } from '@/types/profile';
+import prisma from '../../../../lib/prisma';
+
+export async function POST(req: NextRequest) {
+  const token = await getToken({ req });
+  if (!token || !token.sub) {
+    console.log('invalid token');
+    return NextResponse.json(
+      {
+        body: {
+          message: 'invalid token',
+        }
+      },
+      { status: 401 }
+    );
+  }
+
+  let { coverletter } = (await req.json()) as { coverletter: Coverletter };
+  if (!coverletter) {
+    return NextResponse.json(
+      {
+        body: {
+          message: 'coverletter not provided',
+        }
+      },
+      { status: 400 }
+    );
+  }
+
+  const isValid = CoverletterSchema.safeParse(coverletter);
+  if (!isValid.success) {
+    console.log(`Invalid resume: ${isValid.error}`);
+    return NextResponse.json(
+      {
+        body: {
+          message: 'invalid coverletter',
+        }
+      },
+      { status: 400 }
+    );
+  }
+
+  console.log('Creating a new coverletter...');
+  let createdCoverletter;
+  try {
+    createdCoverletter = await prisma.coverLetters.create({
+      data: {
+        ownerId: token.sub,
+        content: coverletter as any,
+      },
+      select: {
+        id: true,
+      },
+    });
+    console.log('Created a new coverletter with id:', createdCoverletter.id);
+  } catch (err) {
+    console.log(`Create coverletter: ${err}`);
+    return NextResponse.json(
+      {
+        body: {
+          message: 'internal server error',
+        }
+      },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json(
+    {
+      body: {
+        id: createdCoverletter.id,
+      }
+    },
+    { status: 201 }
+  );
+}

--- a/src/app/coverletter-builder/coverletters/[id]/page.tsx
+++ b/src/app/coverletter-builder/coverletters/[id]/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useEffect, useState, useCallback } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import {
   FormViewerContainer,
@@ -14,6 +14,7 @@ import {
   LanguageType,
   ProfessionalExperienceType,
   Resume,
+  Coverletter,
   SkillType,
 } from '@/types/profile';
 import CoverLetterForm from '@/components/coverLettersForm/CoverLetterForm';
@@ -86,7 +87,7 @@ const CoverLetterBuilderPage: FC = () => {
 
   const [resumeInfo, setResumeInfo] = useState(initialState);
 
-  const handleStoredResumeUpdate = async () => {
+  const handleStoredResumeUpdate = useCallback(async () => {
     const response = await fetch(`/api/coverletter/${params.id}`);
     if (response.status !== 200) {
       return;
@@ -94,16 +95,16 @@ const CoverLetterBuilderPage: FC = () => {
     const responseJson = await response.json();
     const resumeProfile: Coverletter | undefined = responseJson.body.coverletter;
 
-    if (!resumeProfile) {
-      return;
-    }
+    //if (!resumeProfile) {
+    //  return;
+    //}
 
-    setResumeInfo(resumeProfile);
-  };
+    //setResumeInfo(resumeProfile);
+  }, [params.id]);
 
   useEffect(() => {
     handleStoredResumeUpdate();
-  }, []);
+  }, [handleStoredResumeUpdate]);
 
   const captureToCanvas = async () => {
     try {

--- a/src/app/coverletter-builder/coverletters/[id]/page.tsx
+++ b/src/app/coverletter-builder/coverletters/[id]/page.tsx
@@ -87,12 +87,12 @@ const CoverLetterBuilderPage: FC = () => {
   const [resumeInfo, setResumeInfo] = useState(initialState);
 
   const handleStoredResumeUpdate = async () => {
-    const response = await fetch('/api/cv');
+    const response = await fetch(`/api/coverletter/${params.id}`);
     if (response.status !== 200) {
       return;
     }
     const responseJson = await response.json();
-    const resumeProfile: Resume | undefined = responseJson.body.profile;
+    const resumeProfile: Coverletter | undefined = responseJson.body.coverletter;
 
     if (!resumeProfile) {
       return;
@@ -174,6 +174,7 @@ const CoverLetterBuilderPage: FC = () => {
       <FormViewerContainer>
         <ResumeFormContainer>
           <CoverLetterForm
+            coverletterId={params.id}
             resumeInfo={resumeInfo}
             setResumeInfo={setResumeInfo}
             refreshStoredResume={handleStoredResumeUpdate}

--- a/src/app/coverletter-builder/coverletters/[id]/page.tsx
+++ b/src/app/coverletter-builder/coverletters/[id]/page.tsx
@@ -6,7 +6,7 @@ import {
   ProfileBuilderContainer,
   ResumeFormContainer,
   ResumeTemplateContainer,
-} from '../page.styles';
+} from '../../../page.styles';
 import PageHeader from '@/components/common/page-header/PageHeader';
 import {
   BasicInfoType,

--- a/src/app/profile-builder/resumes/[id]/page.tsx
+++ b/src/app/profile-builder/resumes/[id]/page.tsx
@@ -20,7 +20,7 @@ const ProfileBuilderPage: FC = () => {
   const [resumeInfo, setResumeInfo] = useState(initialResume());
 
   const handleStoredResumeUpdate = useCallback(async () => {
-    const response = await fetch(`/api/cv/${params.id}`);
+    const response = await fetch(`/api/coverletters/${params.id}`);
     if (response.status !== 200) {
       return;
     }

--- a/src/app/profile-builder/resumes/[id]/page.tsx
+++ b/src/app/profile-builder/resumes/[id]/page.tsx
@@ -20,7 +20,7 @@ const ProfileBuilderPage: FC = () => {
   const [resumeInfo, setResumeInfo] = useState(initialResume());
 
   const handleStoredResumeUpdate = useCallback(async () => {
-    const response = await fetch(`/api/coverletters/${params.id}`);
+    const response = await fetch(`/api/cv/${params.id}`);
     if (response.status !== 200) {
       return;
     }

--- a/src/components/coverLettersForm/CoverLetterForm.tsx
+++ b/src/components/coverLettersForm/CoverLetterForm.tsx
@@ -40,12 +40,14 @@ import LanguagesForm from '../profileBuilderForms/languages-details/LanguagesFor
 import CoverLetterTemplate from '../templates/coverletterTemplate/CoverLetterTemplate';
 
 interface CoverLetterFormProps {
+  coverletterId: string;
   resumeInfo: Resume;
   setResumeInfo: React.Dispatch<React.SetStateAction<Resume>>;
   refreshStoredResume: () => void;
 }
 
 const CoverLetterForm: React.FC<CoverLetterFormProps> = ({
+  coverletterId,
   resumeInfo,
   setResumeInfo,
   refreshStoredResume,
@@ -90,20 +92,15 @@ const CoverLetterForm: React.FC<CoverLetterFormProps> = ({
     });
   };
 
-  // const handleFinalSubmit = () => {
-  //   console.log('Final Form Data:', resumeInfo);
-  //   // Add any additional logic for submitting to a server or performing final actions
-  // };
   const handleSubmitResume = async () => {
-    console.log('Final Form Data:', resumeInfo);
-
     try {
-      const response = await fetch('/api/cv/upload', {
+      const response = await fetch('/api/coverletterChanges', {
         method: 'POST',
-        body: JSON.stringify({ resume: resumeInfo }),
+        body: JSON.stringify({
+          id: coverletterId,
+          coverletter: resumeInfo,
+        }),
       });
-
-      console.log('response:', response);
 
       if (!response.ok) {
         throw new Error('Failed to upload resume');
@@ -115,9 +112,9 @@ const CoverLetterForm: React.FC<CoverLetterFormProps> = ({
       setTimeout(() => {
         setShowSuccessMessage(false);
       }, 3000);
-      console.log('Resume uploaded successfully!');
+      console.log('Coverletter uploaded successfully!');
     } catch (error: any) {
-      console.error('Error uploading resume:', error.message);
+      console.error('Error uploading coverletter:', error.message);
     }
   };
 

--- a/src/components/templates/coverletterTemplate/CoverLetterPreview.tsx
+++ b/src/components/templates/coverletterTemplate/CoverLetterPreview.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/navigation';
 import { FaRegEdit, FaDownload, FaTrashAlt } from 'react-icons/fa';
 import { CiMenuKebab } from 'react-icons/ci';
 import { IoCloseSharp } from 'react-icons/io5';
+import { initialCoverletter } from '@/types/profile';
 import {
   ActionContainer,
   ButtonLabel,
@@ -36,8 +37,30 @@ const CoverLetterPreview = () => {
   const [activeElement, setActiveElement] = useState<string | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
-  const handleCreateNewCoverLetter = () => {
-    router.push('/coverletter-builder');
+  const handleCreateNewCoverLetter = async () => {
+    try {
+      const response = await fetch('/api/resume/upload', {
+        method: 'POST',
+        body: JSON.stringify({ coverletter: initialCoverletter() }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to upload resume');
+      }
+
+      const respJson = await response.json();
+      const id = respJson?.body?.id;
+      if (!id) {
+        throw new Error('Did not receive resume id from server');
+      }
+
+      console.log('Coverletter uploaded successfully with id:', id);
+
+      //router.push(`/coverletter-builder/coverletters/${id}`);
+      router.push('/coverletter-builder');
+    } catch (error: any) {
+      console.error('Error uploading resume:', error.message);
+    }
   };
 
   const handleEditCoverLetter = () => {

--- a/src/components/templates/coverletterTemplate/CoverLetterPreview.tsx
+++ b/src/components/templates/coverletterTemplate/CoverLetterPreview.tsx
@@ -56,8 +56,7 @@ const CoverLetterPreview = () => {
 
       console.log('Coverletter uploaded successfully with id:', id);
 
-      //router.push(`/coverletter-builder/coverletters/${id}`);
-      router.push('/coverletter-builder');
+      router.push(`/coverletter-builder/coverletters/${id}`);
     } catch (error: any) {
       console.error('Error uploading resume:', error.message);
     }

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -178,6 +178,18 @@ export function initialResume(): Resume {
   return resume;
 }
 
+export interface Coverletter {
+  content: string;
+}
+
+export const CoverletterSchema = z.object({
+  content: z.string(),
+});
+
+export function initialCoverletter(): Coverletter {
+  return { content: '' };
+}
+
 // export interface ResumeInfoType {
 //   id: string;
 //   basic: BasicInfoType;


### PR DESCRIPTION
## What

Add the endpoints to handle coverletter saving, fetching and deleting. The storing does not work on the front-end side because it tries to store a resume data type. Probably the front-end can be as simple as having the contact information and then a free form text field where the candidate fill the content.